### PR TITLE
10 Add Redirect Handling to Log In or Create New Account CTA

### DIFF
--- a/complete-application/src/assets/main.css
+++ b/complete-application/src/assets/main.css
@@ -152,3 +152,13 @@ body {
 .change-container {
   flex: 1;
 }
+
+.button-redirect {
+  background: none;
+  border: none;
+  color: #096324;
+  font-size: 18px;
+  font-family: sans-serif;
+  padding: 0;
+
+}

--- a/complete-application/src/views/HomeView.vue
+++ b/complete-application/src/views/HomeView.vue
@@ -1,9 +1,19 @@
+
 <template>
   <div class="column-container">
     <div class="content-container">
       <div style="margin-bottom: 100px;">
         <h1>Welcome to Changebank</h1>
-        <p>To get started, <a style="cursor: pointer">log in or create a new account</a>.</p>
+        <p>
+            To get started,
+            <button className="button-redirect" style = "cursor: pointer"  @click="fusionAuth.login()">
+            log in
+            </button>
+            or
+            <button className="button-redirect" style = "cursor: pointer"  @click="fusionAuth.register()">
+            create a new account.
+            </button>
+          </p>
       </div>
     </div>
 
@@ -12,3 +22,10 @@
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import {useFusionAuth} from "@fusionauth/vue-sdk";
+
+const fusionAuth = useFusionAuth();
+
+</script>


### PR DESCRIPTION
### **What is this PR and why do we need it?**
Adds handling to "log in" to redirect users to log in flow
Adds handling to "create a new account" to redirect users to register flow

We are switching from using an anchor to using a button here for accessibility purposes. There should be no visible changes to the UI and clicking the log in or create a new account buttons on the home page should respectively redirect to log in and register flow.

https://github.com/FusionAuth/fusionauth-quickstart-javascript-vue-web/issues/10

**Pre-Merge Checklist (if applicable)**

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.