### PR TITLE
3 Change "Dev" Script to "Start"

### DIFF
--- a/complete-application/package.json
+++ b/complete-application/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "start": "vite",
     "build": "run-p type-check build-only",
     "preview": "vite preview",
     "build-only": "vite build",


### PR DESCRIPTION
### **What is this PR and why do we need it?**
To maintain consistency amongst the quickstart applications and align with the readme documentation this change switches the "dev" script to be named "start"

To Test:
Run the following command and ensure the quickstart application boots up locally `npm run start`

https://github.com/FusionAuth/fusionauth-quickstart-javascript-vue-web/issues/3

**Pre-Merge Checklist (if applicable)**

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.