### PR TITLE
21 Build Out Example postLogoutRedirectUri Routing

### DIFF
--- a/complete-application/package-lock.json
+++ b/complete-application/package-lock.json
@@ -8,7 +8,7 @@
       "name": "complete-application",
       "version": "0.0.0",
       "dependencies": {
-        "@fusionauth/vue-sdk": "^1.1.0",
+        "@fusionauth/vue-sdk": "^1.2.0",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       },
@@ -387,12 +387,11 @@
       }
     },
     "node_modules/@fusionauth/vue-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@fusionauth/vue-sdk/-/vue-sdk-1.1.0.tgz",
-      "integrity": "sha512-esK5frLBcW+8MaHBNmwcHi4+zKEghln/uZfgPIvEgQFJl89AGvEwISxKV+o6PKP8+/04v0XUwe8Px6c+RYxsew==",
-      "license": "Apache",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@fusionauth/vue-sdk/-/vue-sdk-1.2.0.tgz",
+      "integrity": "sha512-tQUZXngC4jp83iQ8kAzhPkZ7Jxak3+ztonzLp6dqCWdy7wCHVqGu3+d8XRdHvZ7b17yid1hprJHsAPwAgr4f2g==",
       "peerDependencies": {
-        "vue": "^3.0.0"
+        "vue": ">=3.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/complete-application/package.json
+++ b/complete-application/package.json
@@ -10,7 +10,7 @@
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false"
   },
   "dependencies": {
-    "@fusionauth/vue-sdk": "^1.1.0",
+    "@fusionauth/vue-sdk": "^1.2.0",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"
   },

--- a/complete-application/src/main.ts
+++ b/complete-application/src/main.ts
@@ -12,6 +12,7 @@ app.use(FusionAuthVuePlugin, {
   clientId: 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e',
   serverUrl: 'http://localhost:9011',
   redirectUri: 'http://localhost:5173',
+  postLogoutRedirectUri: 'http://localhost:5173/logged-out',
   shouldAutoFetchUserInfo: true,
   shouldAutoRefresh: true,
   scope: 'openid email profile offline_access'

--- a/complete-application/src/router/index.ts
+++ b/complete-application/src/router/index.ts
@@ -21,6 +21,12 @@ const router = createRouter({
       beforeEnter: routeGuard(false, '/account')
     },
     {
+      path: '/logged-out',
+      name: 'home',
+      component: HomeView,
+      beforeEnter: routeGuard(false, '/account')
+    },
+    {
       path: '/account',
       name: 'account',
       component: () => import('../views/AccountView.vue'),

--- a/complete-application/src/router/index.ts
+++ b/complete-application/src/router/index.ts
@@ -18,13 +18,8 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView,
-      beforeEnter: routeGuard(false, '/account')
-    },
-    {
-      path: '/logged-out',
-      name: 'home',
-      component: HomeView,
-      beforeEnter: routeGuard(false, '/account')
+      beforeEnter: routeGuard(false, '/account'),
+      alias: '/logged-out'
     },
     {
       path: '/account',

--- a/kickstart/kickstart.json
+++ b/kickstart/kickstart.json
@@ -2,6 +2,7 @@
   "variables": {
     "allowedOrigin": "http://localhost:5173",
     "authorizedRedirectURL": "http://localhost:5173",
+    "authorizedPostLogoutURL": "http://localhost:5173/logged-out",
     "authorizedOriginURL": "http://localhost:5173",
     "logoutURL": "http://localhost:5173",
     "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
@@ -90,6 +91,7 @@
           "name": "Example app",
           "oauthConfiguration": {
             "authorizedRedirectURLs": [
+              "#{authorizedPostLogoutURL}",
               "#{authorizedRedirectURL}"
             ],
             "authorizedOriginURLs": [


### PR DESCRIPTION
### What is this PR and why do we need it?
The current implementation of `postLogoutRedirectUri` could benefit from a more illustrative example for users. This PR adds routing that demonstrates the behavior expected when the `postLogoutRedirectUri` is defined vs undefined.

https://github.com/FusionAuth/fusionauth-quickstart-javascript-vue-web/issues/21

To Test:

1. Login and Logout in the quickstart application observing the url on logout, this should redirect to `/logged-out`.
2. Comment out the `postLogoutRedirectUri` in the `main.ts` file and restart the server
3. Repeat step one and ensure the redirect on log out goes to `/` as defined in the `redirectUri`


Pre-Merge Checklist (if applicable)
[x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.